### PR TITLE
fix py2 stdin encoding

### DIFF
--- a/lmr
+++ b/lmr
@@ -18,7 +18,7 @@ shift $((OPTIND-1))
 if [ "$#" -ne 5 ]; then
     usage
 fi
-   
+
 BLOCKSIZE="$1"
 NUM_HASHING_SEGS="$2"
 MAPPER="$3"
@@ -63,14 +63,14 @@ function clean_up() {
     fi
     rm "$HASHING_SCRIPT"
 } >&2
-trap 'clean_up; exit' SIGHUP SIGINT SIGTERM 
+trap 'clean_up; exit' SIGHUP SIGINT SIGTERM
 
 cat <<EOF > "${HASHING_SCRIPT}"
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
-import sys, gzip, re, os, fileinput, io
-def tokens(str1): return re.findall('[a-z]+', str1.lower())
+import sys, gzip, re, os, fileinput, io, hashlib
+
 N_REDUCER, MAPPER_ID, BASE_DIR  = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
 
 # print(MAPPER_ID, ' ', file = sys.stderr, end = '')
@@ -83,13 +83,16 @@ def outfile(seg_id):
     except OSError : pass
     # return io.open('{}/{:02}'.format( segdir, base64.urlsafe_b64encode() ), 'at', buffering=1, encoding=None)
     # return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'at', buffering=1, encoding=None)
-    return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'wt', encoding = 'utf-8')
+    return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'wt')
 
-seg_file = [ outfile(seg_id) for seg_id in range(N_REDUCER) ]
+def text_hash(text):
+    return int(hashlib.md5(text.encode('utf-8')).hexdigest(), 16)
 
-for line in fileinput.input(sys.argv[4:]):
-    key, _,value = line[:-1].partition('\t')
-    print( '{}\t{}'.format(key, value), file = seg_file[hash(key) % N_REDUCER])
+seg_file = [outfile(seg_id) for seg_id in range(N_REDUCER)]
+
+for line in io.open(sys.stdin.fileno(), 'rt'):
+    key, _, value = line[:-1].partition('\t')
+    print('{}\t{}'.format(key, value), file=seg_file[text_hash(key) % N_REDUCER])
 fileinput.close()
 for seg_id in range(N_REDUCER): seg_file[seg_id].close()
 EOF
@@ -97,7 +100,7 @@ EOF
 
 mkdir "$5" || exit 1
 echo  $' \e[1;33m>>>\e[m' Mappers running...
-echo 
+echo
 parallel --pipe --block "${BLOCKSIZE}"  --ungroup   "echo -n $'\e[s\e[F\e[2K           #{#}\e[u' ; ${MAPPER}  | python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR " # pipe to here
 # parallel --pipe --block "$1" "$3 | python $HASHING_SCRIPT $2 1 $TEMPDIR" # io.open line buffering
 # echo $TEMPDIR
@@ -105,12 +108,12 @@ parallel   --ungroup "sort -k 1,1 -t $'\t' -s {}/*  | ${REDUCER} > '${OUTPUT_DIR
 echo  $' \e[1;33m>>>\e[m' Reducer running. Temporary input directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
 {
     clean_up
-    echo 
+    echo
     if [ $keep_mapper_out = true ] ; then
         echo  $' \e[1;33m*\e[m' Mapper output directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
     fi
-    
+
     echo  $' \e[1;33m*\e[m' Output directory: $'\e[1;32m'"$OUTPUT_DIR"$'\e[m'
     echo  $' \e[1;33m*\e[m' Elasped time: $'\e[1;32m'$(timer $START_TIME)$'\e[m'
-    
+
 } >&2


### PR DESCRIPTION
UTF-8 stream causes problem in hashing.py under py2 while partitioning str objects from stdin. Set UTF-8 as default system encoding to read stream from stdin as unicode str.
