### PR TITLE
use a different hash function

### DIFF
--- a/lmr
+++ b/lmr
@@ -18,7 +18,7 @@ shift $((OPTIND-1))
 if [ "$#" -ne 5 ]; then
     usage
 fi
-   
+
 BLOCKSIZE="$1"
 NUM_HASHING_SEGS="$2"
 MAPPER="$3"
@@ -63,14 +63,14 @@ function clean_up() {
     fi
     rm "$HASHING_SCRIPT"
 } >&2
-trap 'clean_up; exit' SIGHUP SIGINT SIGTERM 
+trap 'clean_up; exit' SIGHUP SIGINT SIGTERM
 
 cat <<EOF > "${HASHING_SCRIPT}"
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
-import sys, gzip, re, os, fileinput, io
-def tokens(str1): return re.findall('[a-z]+', str1.lower())
+import sys, gzip, re, os, fileinput, io, hashlib
+
 N_REDUCER, MAPPER_ID, BASE_DIR  = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
 
 # print(MAPPER_ID, ' ', file = sys.stderr, end = '')
@@ -83,13 +83,16 @@ def outfile(seg_id):
     except OSError : pass
     # return io.open('{}/{:02}'.format( segdir, base64.urlsafe_b64encode() ), 'at', buffering=1, encoding=None)
     # return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'at', buffering=1, encoding=None)
-    return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'wt', encoding = 'utf-8')
+    return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'wt')
 
-seg_file = [ outfile(seg_id) for seg_id in range(N_REDUCER) ]
+def text_hash(text):
+    return int(hashlib.md5(text.encode('utf-8')).hexdigest(), 16)
 
-for line in fileinput.input(sys.argv[4:]):
-    key, _,value = line[:-1].partition('\t')
-    print( '{}\t{}'.format(key, value), file = seg_file[hash(key) % N_REDUCER])
+seg_file = [outfile(seg_id) for seg_id in range(N_REDUCER)]
+
+for line in io.open(sys.stdin.fileno(), 'rt'):
+    key, _, value = line[:-1].partition('\t')
+    print('{}\t{}'.format(key, value), file=seg_file[text_hash(key) % N_REDUCER])
 fileinput.close()
 for seg_id in range(N_REDUCER): seg_file[seg_id].close()
 EOF
@@ -97,7 +100,7 @@ EOF
 
 mkdir "$5" || exit 1
 echo  $' \e[1;33m>>>\e[m' Mappers running...
-echo 
+echo
 parallel --pipe --block "${BLOCKSIZE}"  --ungroup   "echo -n $'\e[s\e[F\e[2K           #{#}\e[u' ; ${MAPPER}  | python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR " # pipe to here
 # parallel --pipe --block "$1" "$3 | python $HASHING_SCRIPT $2 1 $TEMPDIR" # io.open line buffering
 # echo $TEMPDIR
@@ -105,12 +108,12 @@ parallel   --ungroup "sort -k 1,1 -t $'\t' -s {}/*  | ${REDUCER} > '${OUTPUT_DIR
 echo  $' \e[1;33m>>>\e[m' Reducer running. Temporary input directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
 {
     clean_up
-    echo 
+    echo
     if [ $keep_mapper_out = true ] ; then
         echo  $' \e[1;33m*\e[m' Mapper output directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
     fi
-    
+
     echo  $' \e[1;33m*\e[m' Output directory: $'\e[1;32m'"$OUTPUT_DIR"$'\e[m'
     echo  $' \e[1;33m*\e[m' Elasped time: $'\e[1;32m'$(timer $START_TIME)$'\e[m'
-    
+
 } >&2

--- a/lmr
+++ b/lmr
@@ -68,31 +68,24 @@ trap 'clean_up; exit' SIGHUP SIGINT SIGTERM
 cat <<EOF > "${HASHING_SCRIPT}"
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
-import sys, gzip, re, os, fileinput, io, hashlib
+import sys, os, fileinput
 
 N_REDUCER, MAPPER_ID, BASE_DIR  = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
 
 # print(MAPPER_ID, ' ', file = sys.stderr, end = '')
 # print(MAPPER_ID, end = ' ')
 
-import base64
 def outfile(seg_id):
     segdir = '{}/reducer-{:02}'.format(BASE_DIR, seg_id)
     try: os.makedirs(segdir)
     except OSError : pass
-    # return io.open('{}/{:02}'.format( segdir, base64.urlsafe_b64encode() ), 'at', buffering=1, encoding=None)
-    # return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'at', buffering=1, encoding=None)
-    return io.open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'wt')
-
-def text_hash(text):
-    return int(hashlib.md5(text.encode('utf-8')).hexdigest(), 16)
+    return open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'w')
 
 seg_file = [outfile(seg_id) for seg_id in range(N_REDUCER)]
 
-for line in io.open(sys.stdin.fileno(), 'rt'):
-    key, _, value = line[:-1].partition('\t')
-    print('{}\t{}'.format(key, value), file=seg_file[text_hash(key) % N_REDUCER])
+for line in fileinput.input(sys.argv[4:]):
+    key, _, value = line.rstrip().partition('\t')
+    print(key, value, sep='\t', file=seg_file[hash(key) % N_REDUCER])
 fileinput.close()
 for seg_id in range(N_REDUCER): seg_file[seg_id].close()
 EOF
@@ -101,10 +94,10 @@ EOF
 mkdir "$5" || exit 1
 echo  $' \e[1;33m>>>\e[m' Mappers running...
 echo
-parallel --pipe --block "${BLOCKSIZE}"  --ungroup   "echo -n $'\e[s\e[F\e[2K           #{#}\e[u' ; ${MAPPER}  | python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR " # pipe to here
+parallel --pipe --block "${BLOCKSIZE}" --ungroup "echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; ${MAPPER} | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" # pipe to here
 # parallel --pipe --block "$1" "$3 | python $HASHING_SCRIPT $2 1 $TEMPDIR" # io.open line buffering
 # echo $TEMPDIR
-parallel   --ungroup "sort -k 1,1 -t $'\t' -s {}/*  | ${REDUCER} > '${OUTPUT_DIR}/{/.}'"  ::: "${TEMPDIR}"/*
+parallel --ungroup "sort -k 1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'"  ::: "${TEMPDIR}"/*
 echo  $' \e[1;33m>>>\e[m' Reducer running. Temporary input directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
 {
     clean_up

--- a/lmr
+++ b/lmr
@@ -76,10 +76,14 @@ START_TIME=timer
 
 echo $' \e[1;33m>>>\e[m' Mappers running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
 echo
-parallel --pipe --block "${BLOCKSIZE}" --ungroup "echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; ${MAPPER} | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" # pipe to here
 
-echo -n $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
-parallel --ungroup "sort -k 1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'"  ::: "${TEMPDIR}"/*
+parallel --pipe --block-size "${BLOCKSIZE}" --ungroup --halt now,fail=1 \
+"echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; ${MAPPER} | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" &&
+{
+    echo -n $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
+    parallel -u --halt now,fail=1 \
+    "sort -k1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'"  ::: "${TEMPDIR}"/*
+} &&
 {
     echo
     echo  $' \e[1;33m*\e[m' Output directory: $'\e[1;32m'"$OUTPUT_DIR"$'\e[m'

--- a/lmr
+++ b/lmr
@@ -37,6 +37,7 @@ HASHING_SCRIPT=`mktemp hashing.py.XXXX`
 }>&2
 TEMPDIR=`mktemp -d mapper_tmp.XXXX`
 {
+    mkdir `seq -f $TEMPDIR'/reducer-%02g' 0 $NUM_HASHING_SEGS`
     echo $' \e[1;32m>>>\e[m Temporary mapper output directory created: \e[1;32m'$TEMPDIR$'\e[m'
 }>&2
 
@@ -63,19 +64,12 @@ import sys, os, fileinput
 
 N_REDUCER, MAPPER_ID, BASE_DIR  = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
 
-def outfile(seg_id):
-    segdir = os.path.join(BASE_DIR, f"reducer-{seg_id:02}")
-    try: os.makedirs(segdir)
-    except OSError : pass
-    return open(f"{segdir}/mapper-{MAPPER_ID:02}", 'w')
-
-seg_file = [outfile(seg_id) for seg_id in range(N_REDUCER)]
+seg_file = [open(os.path.join(BASE_DIR, f"reducer-{seg_id:02}", f"mapper-{MAPPER_ID:02}"), 'w')
+            for seg_id in range(N_REDUCER)]
 
 for line in fileinput.input(sys.argv[4:]):
     key, _, value = line.rstrip().partition('\t')
     print(key, value, sep='\t', file=seg_file[hash(key) % N_REDUCER])
-fileinput.close()
-for seg_id in range(N_REDUCER): seg_file[seg_id].close()
 EOF
 
 START_TIME=timer

--- a/lmr
+++ b/lmr
@@ -83,7 +83,7 @@ parallel --pipe --block-size "${BLOCKSIZE}" --ungroup --halt now,fail=1 \
 {
     echo $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
     parallel --ungroup --halt now,fail=1 \
-    "sort -k1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'"  ::: "${TEMPDIR}"/*
+    "sort -k1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'" ::: "${TEMPDIR}"/*
 } &&
 {
     echo

--- a/lmr
+++ b/lmr
@@ -83,12 +83,12 @@ parallel --pipe --block-size "${BLOCKSIZE}" --ungroup --halt now,fail=1 \
 {
     echo $' \e[1;33m>>>\e[m' Sort parts running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
     parallel --bar --ungroup --halt now,fail=1 \
-    "sort -k1,1 -t $'\t' -o {} {}" ::: "${TEMPDIR}"/*/*
+    "LC_ALL=C sort -k1,1 -t $'\t' -o {} {}" ::: "${TEMPDIR}"/*/*
 } &&
 {
     echo $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
     parallel --bar --ungroup --halt now,fail=1 \
-    "sort -m -k1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'" ::: "${TEMPDIR}"/*
+    "LC_ALL=C sort -m -k1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'" ::: "${TEMPDIR}"/*
 } &&
 {
     echo

--- a/lmr
+++ b/lmr
@@ -81,8 +81,8 @@ echo
 parallel --pipe --block-size "${BLOCKSIZE}" --ungroup --halt now,fail=1 \
 "echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; ${MAPPER} | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" &&
 {
-    echo -n $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
-    parallel -u --halt now,fail=1 \
+    echo $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
+    parallel --ungroup --halt now,fail=1 \
     "sort -k1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'"  ::: "${TEMPDIR}"/*
 } &&
 {

--- a/lmr
+++ b/lmr
@@ -31,11 +31,11 @@ function timer()
     date -d@$dt -u +%H:%M:%S 2>/dev/null || date -u -r $dt +%T
 }
 
-HASHING_SCRIPT=`mktemp /tmp/hashing.py.XXXX || mktemp hashing.py.XXXX`
+HASHING_SCRIPT=`mktemp hashing.py.XXXX`
 {
     echo $' \e[1;32m>>>\e[m Temporary mapper hashing script created: \e[1;32m'$HASHING_SCRIPT$'\e[m'
 }>&2
-TEMPDIR=`mktemp -d /tmp/mapper_tmp.XXXX || mktemp -d mapper_tmp.XXXX`
+TEMPDIR=`mktemp -d mapper_tmp.XXXX`
 {
     mkdir `seq -f $TEMPDIR'/reducer-%02g' 0 $((NUM_HASHING_SEGS-1))`
     echo $' \e[1;32m>>>\e[m Temporary mapper output directory created: \e[1;32m'$TEMPDIR$'\e[m'
@@ -79,7 +79,7 @@ echo $' \e[1;33m>>>\e[m' Mappers running... $'\e[1;33m'$(timer START_TIME)$'\e[m
 echo
 
 parallel --pipe --block-size "${BLOCKSIZE}" --ungroup --halt now,fail=1 \
-"echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; ${MAPPER} | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" &&
+"echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; $MAPPER | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" &&
 {
     echo $' \e[1;33m>>>\e[m' Sort parts running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
     parallel --bar --ungroup --halt now,fail=1 \
@@ -88,7 +88,7 @@ parallel --pipe --block-size "${BLOCKSIZE}" --ungroup --halt now,fail=1 \
 {
     echo $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
     parallel --bar --ungroup --halt now,fail=1 \
-    "LC_ALL=C sort -m -k1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'" ::: "${TEMPDIR}"/*
+    "LC_ALL=C sort -m -k1,1 -t $'\t' {}/* | $REDUCER > '$OUTPUT_DIR/{/.}'" ::: "${TEMPDIR}"/*
 } &&
 {
     echo

--- a/lmr
+++ b/lmr
@@ -81,9 +81,14 @@ echo
 parallel --pipe --block-size "${BLOCKSIZE}" --ungroup --halt now,fail=1 \
 "echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; ${MAPPER} | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" &&
 {
+    echo $' \e[1;33m>>>\e[m' Sort parts running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
+    parallel --bar --ungroup --halt now,fail=1 \
+    "sort -k1,1 -t $'\t' -o {} {}" ::: "${TEMPDIR}"/*/*
+} &&
+{
     echo $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
-    parallel --ungroup --halt now,fail=1 \
-    "sort -k1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'" ::: "${TEMPDIR}"/*
+    parallel --bar --ungroup --halt now,fail=1 \
+    "sort -m -k1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'" ::: "${TEMPDIR}"/*
 } &&
 {
     echo

--- a/lmr
+++ b/lmr
@@ -12,7 +12,7 @@ do
 done
 shift $((OPTIND-1))
 
-[ "$#" -ne 5 ] && usage
+[ $# -ne 5 ] && usage
 
 BLOCKSIZE="$1"
 NUM_HASHING_SEGS="$2"
@@ -37,7 +37,7 @@ HASHING_SCRIPT=`mktemp hashing.py.XXXX`
 }>&2
 TEMPDIR=`mktemp -d mapper_tmp.XXXX`
 {
-    mkdir `seq -f $TEMPDIR'/reducer-%02g' 0 $NUM_HASHING_SEGS`
+    mkdir `seq -f $TEMPDIR'/reducer-%02g' 0 $((NUM_HASHING_SEGS-1))`
     echo $' \e[1;32m>>>\e[m Temporary mapper output directory created: \e[1;32m'$TEMPDIR$'\e[m'
 }>&2
 

--- a/lmr
+++ b/lmr
@@ -55,7 +55,8 @@ function clean_up() {
     echo  $' \e[1;32m>>>\e[m' Temporary hashing script deleted: $'\e[1;32m'"$HASHING_SCRIPT"$'\e[m' ||
     echo  $' \e[1;31m*\e[m' Failed to delete hashing script: $'\e[1;32m'"$HASHING_SCRIPT"$'\e[m'
 } >&2
-trap 'clean_up; exit' SIGHUP SIGINT SIGTERM EXIT
+trap 'clean_up' EXIT
+trap 'exit' SIGHUP SIGINT SIGTERM
 
 cat <<EOF > "${HASHING_SCRIPT}"
 #!/usr/bin/env python

--- a/lmr
+++ b/lmr
@@ -31,11 +31,11 @@ function timer()
     date -d@$dt -u +%H:%M:%S 2>/dev/null || date -u -r $dt +%T
 }
 
-HASHING_SCRIPT=`mktemp hashing.py.XXXX`
+HASHING_SCRIPT=`mktemp /tmp/hashing.py.XXXX || mktemp hashing.py.XXXX`
 {
     echo $' \e[1;32m>>>\e[m Temporary mapper hashing script created: \e[1;32m'$HASHING_SCRIPT$'\e[m'
 }>&2
-TEMPDIR=`mktemp -d mapper_tmp.XXXX`
+TEMPDIR=`mktemp -d /tmp/mapper_tmp.XXXX || mktemp -d mapper_tmp.XXXX`
 {
     mkdir `seq -f $TEMPDIR'/reducer-%02g' 0 $((NUM_HASHING_SEGS-1))`
     echo $' \e[1;32m>>>\e[m Temporary mapper output directory created: \e[1;32m'$TEMPDIR$'\e[m'

--- a/lmr
+++ b/lmr
@@ -3,21 +3,16 @@
 function usage() { echo "Usage: $0 [-k] <BLOCKSIZE> <NUM_HASHING_SEGS> <MAPPER> <REDUCER> <OUTPUT_DIR>" 1>&2; exit 1; }
 
 keep_mapper_out=false
-while getopts "k" o; do
-    case "${o}" in
-        k)
-            keep_mapper_out=true
-            ;;
-        *)
-            usage
-            ;;
+while getopts ":k" OPTION
+do
+    case $OPTION in
+        k) keep_mapper_out=true;;
+        ?) usage;;
     esac
 done
 shift $((OPTIND-1))
 
-if [ "$#" -ne 5 ]; then
-    usage
-fi
+[ "$#" -ne 5 ] && usage
 
 BLOCKSIZE="$1"
 NUM_HASHING_SEGS="$2"
@@ -25,32 +20,24 @@ MAPPER="$3"
 REDUCER="$4"
 OUTPUT_DIR="$5"
 
+mkdir "$OUTPUT_DIR" || exit 1
+
 function timer()
 {
-    if [[ $# -eq 0 ]]; then
-        echo $(date '+%s')
-    else
-        local  stime=$1
-        etime=$(date '+%s')
-
-        if [[ -z "$stime" ]]; then stime=$etime; fi
-
-        dt=$((etime - stime))
-        ds=$((dt % 60))
-        dm=$(((dt / 60) % 60))
-        dh=$((dt / 3600))
-        printf '%d:%02d:%02d' $dh $dm $ds
-    fi
+    local stime=$1
+    [[ -z $stime ]] && stime=$START_TIME
+    [[ -z $stime ]] && stime=0
+    dt=$((SECONDS - stime))
+    date -d@$dt -u +%H:%M:%S 2>/dev/null || date -u -r $dt +%T
 }
 
-START_TIME=$(timer)
-
 HASHING_SCRIPT=`mktemp hashing.py.XXXX`
-echo hashing script $HASHING_SCRIPT
-# trap 'rm -r "$HASHING_SCRIPT"' SIGHUP SIGINT SIGTERM
+{
+    echo $' \e[1;32m>>>\e[m Temporary mapper hashing script created: \e[1;32m'$HASHING_SCRIPT$'\e[m'
+}>&2
 TEMPDIR=`mktemp -d mapper_tmp.XXXX`
 {
-    echo $' \e[1;32m>>>\e[m' Temporary output directory for mapper created: $'\e[1;32m'$TEMPDIR$'\e[m'
+    echo $' \e[1;32m>>>\e[m Temporary mapper output directory created: \e[1;32m'$TEMPDIR$'\e[m'
 }>&2
 
 function clean_up() {
@@ -60,10 +47,14 @@ function clean_up() {
         rm -r "$TEMPDIR" &&
         echo  $' \e[1;32m>>>\e[m' Temporary directory deleted: $'\e[1;32m'"$TEMPDIR"$'\e[m' ||
         echo  $' \e[1;31m*\e[m' Failed to delete temporary directoy: $'\e[1;32m'"$TEMPDIR"$'\e[m'
+    else
+        echo  $' \e[1;33m*\e[m' Mapper output directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
     fi
-    rm "$HASHING_SCRIPT"
+    rm "$HASHING_SCRIPT" &&
+    echo  $' \e[1;32m>>>\e[m' Temporary hashing script deleted: $'\e[1;32m'"$HASHING_SCRIPT"$'\e[m' ||
+    echo  $' \e[1;31m*\e[m' Failed to delete hashing script: $'\e[1;32m'"$HASHING_SCRIPT"$'\e[m'
 } >&2
-trap 'clean_up; exit' SIGHUP SIGINT SIGTERM
+trap 'clean_up; exit' SIGHUP SIGINT SIGTERM EXIT
 
 cat <<EOF > "${HASHING_SCRIPT}"
 #!/usr/bin/env python
@@ -72,14 +63,11 @@ import sys, os, fileinput
 
 N_REDUCER, MAPPER_ID, BASE_DIR  = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
 
-# print(MAPPER_ID, ' ', file = sys.stderr, end = '')
-# print(MAPPER_ID, end = ' ')
-
 def outfile(seg_id):
-    segdir = '{}/reducer-{:02}'.format(BASE_DIR, seg_id)
+    segdir = os.path.join(BASE_DIR, f"reducer-{seg_id:02}")
     try: os.makedirs(segdir)
     except OSError : pass
-    return open('{}/mapper-{:02}'.format( segdir, MAPPER_ID ), 'w')
+    return open(f"{segdir}/mapper-{MAPPER_ID:02}", 'w')
 
 seg_file = [outfile(seg_id) for seg_id in range(N_REDUCER)]
 
@@ -90,23 +78,16 @@ fileinput.close()
 for seg_id in range(N_REDUCER): seg_file[seg_id].close()
 EOF
 
+START_TIME=timer
 
-mkdir "$5" || exit 1
-echo  $' \e[1;33m>>>\e[m' Mappers running...
+echo $' \e[1;33m>>>\e[m' Mappers running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
 echo
 parallel --pipe --block "${BLOCKSIZE}" --ungroup "echo -n $'\e[s\e[F\e[2K           #{#}\e[u'; ${MAPPER} | PYTHONHASHSEED=0 python $HASHING_SCRIPT ${NUM_HASHING_SEGS} {#} $TEMPDIR" # pipe to here
-# parallel --pipe --block "$1" "$3 | python $HASHING_SCRIPT $2 1 $TEMPDIR" # io.open line buffering
-# echo $TEMPDIR
+
+echo -n $' \e[1;33m>>>\e[m' Reducer running... $'\e[1;33m'$(timer START_TIME)$'\e[m'
 parallel --ungroup "sort -k 1,1 -t $'\t' {}/* | ${REDUCER} > '${OUTPUT_DIR}/{/.}'"  ::: "${TEMPDIR}"/*
-echo  $' \e[1;33m>>>\e[m' Reducer running. Temporary input directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
 {
-    clean_up
     echo
-    if [ $keep_mapper_out = true ] ; then
-        echo  $' \e[1;33m*\e[m' Mapper output directory: $'\e[1;32m'"$TEMPDIR"$'\e[m'
-    fi
-
     echo  $' \e[1;33m*\e[m' Output directory: $'\e[1;32m'"$OUTPUT_DIR"$'\e[m'
-    echo  $' \e[1;33m*\e[m' Elasped time: $'\e[1;32m'$(timer $START_TIME)$'\e[m'
-
+    echo  $' \e[1;33m*\e[m' Elasped time: $'\e[1;32m'$(timer START_TIME)$'\e[m'
 } >&2


### PR DESCRIPTION
The built-in `hash` function uses a random hash seed by default for python>=3.3. 
**hash function in Python 3.3 returns different results between sessions**
[https://stackoverflow.com/questions/27522626](https://stackoverflow.com/questions/27522626)

I then turn to use `md5 ` in `hashlib` as the new hash function.
